### PR TITLE
Update spec file for new release 1.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # RPM packaging
 #
 name = argus-pdp
-version = 1.6.0
+version = 1.6.1
 release = 1
 
 dist_url = http://argus-authz.github.com/$(name)/distrib/$(name)-$(version).tar.gz

--- a/fedora/argus-pdp.spec.in
+++ b/fedora/argus-pdp.spec.in
@@ -115,44 +115,48 @@ fi
 %{_defaultdocdir}/argus/pdp/LICENSE
 %{_defaultdocdir}/argus/pdp/RELEASE-NOTES
 %dir %{_localstatedir}/lib/argus/pdp/lib
-%{_localstatedir}/lib/argus/pdp/lib/argus-pdp-1.6.0.jar
-%{_localstatedir}/lib/argus/pdp/lib/commons-codec-1.3.jar
-%{_localstatedir}/lib/argus/pdp/lib/commons-collections-3.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/commons-httpclient-3.0.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/commons-lang-2.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/commons-io-1.4.jar
-%{_localstatedir}/lib/argus/pdp/lib/herasaf-xacml-core-1.0.0-M2.jar
-%{_localstatedir}/lib/argus/pdp/lib/ini4j-0.5.2.jar
-%{_localstatedir}/lib/argus/pdp/lib/jcl-over-slf4j-1.5.8.jar
-%{_localstatedir}/lib/argus/pdp/lib/jetty-6.1.18.jar
-%{_localstatedir}/lib/argus/pdp/lib/jetty-java5-threadpool-6.1.18.jar
-%{_localstatedir}/lib/argus/pdp/lib/jetty-sslengine-6.1.18.jar
-%{_localstatedir}/lib/argus/pdp/lib/jetty-util-6.1.18.jar
-%{_localstatedir}/lib/argus/pdp/lib/joda-time-1.6.jar
-%{_localstatedir}/lib/argus/pdp/lib/jul-to-slf4j-1.5.8.jar
-%{_localstatedir}/lib/argus/pdp/lib/log4j-over-slf4j-1.5.8.jar
-%{_localstatedir}/lib/argus/pdp/lib/logback-classic-0.9.18.jar
-%{_localstatedir}/lib/argus/pdp/lib/logback-core-0.9.18.jar
-%{_localstatedir}/lib/argus/pdp/lib/not-yet-commons-ssl-0.3.9.jar
-%{_localstatedir}/lib/argus/pdp/lib/opensaml-2.3.2.jar
-%{_localstatedir}/lib/argus/pdp/lib/openws-1.3.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/servlet-api-2.5-20081211.jar
-%{_localstatedir}/lib/argus/pdp/lib/slf4j-api-1.5.8.jar
-%{_localstatedir}/lib/argus/pdp/lib/velocity-1.5.jar
-%{_localstatedir}/lib/argus/pdp/lib/xmlsec-1.4.3.jar
-%{_localstatedir}/lib/argus/pdp/lib/xmltooling-1.2.2.jar
+%{_localstatedir}/lib/argus/pdp/lib/argus-pdp-@@SPEC_VERSION@@.jar
+%{_localstatedir}/lib/argus/pdp/lib/commons-codec-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/commons-collections-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/commons-httpclient-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/commons-lang-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/commons-io-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/herasaf-xacml-core-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/ini4j-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/jcl-over-slf4j-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/jetty-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/jetty-java5-threadpool-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/jetty-sslengine-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/jetty-util-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/joda-time-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/jul-to-slf4j-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/log4j-over-slf4j-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/logback-classic-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/logback-core-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/not-yet-commons-ssl-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/opensaml-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/openws-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/servlet-api-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/slf4j-api-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/velocity-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/xmlsec-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/xmltooling-*.jar
 %dir %{_localstatedir}/lib/argus/pdp/lib/endorsed
-%{_localstatedir}/lib/argus/pdp/lib/endorsed/serializer-2.7.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/endorsed/xalan-2.7.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/endorsed/xercesImpl-2.9.1.jar
-%{_localstatedir}/lib/argus/pdp/lib/endorsed/xml-apis-1.3.04.jar
-%{_localstatedir}/lib/argus/pdp/lib/endorsed/xml-resolver-1.2.jar
+%{_localstatedir}/lib/argus/pdp/lib/endorsed/serializer-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/endorsed/xalan-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/endorsed/xercesImpl-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/endorsed/xml-apis-*.jar
+%{_localstatedir}/lib/argus/pdp/lib/endorsed/xml-resolver-*.jar
 %dir %{_localstatedir}/lib/argus/pdp/lib/provided
 %{_localstatedir}/lib/argus/pdp/lib/provided/bcprov-*.jar
 %{_localstatedir}/lib/argus/pdp/lib/provided/canl-*.jar
 %dir %{_localstatedir}/log/argus/pdp
 
 %changelog
+* Thu Oct  2 2014 Mischa Salle <msalle@nikhef.nl> 1.6.1-1
+- Replace exact versions, except argus-pdp, in filelist with wildcard.
+- Upstream version 1.6.1 for EMI-3.
+
 * Thu Nov 18 2012 Valery Tschopp <valery.tschopp@switch.ch> 1.6.0-1 
 - Upstream version 1.6.0 for EMI-3.
 


### PR DESCRIPTION
Change all exact versions in the filelist into wildcards, except for the
argus-pdp jar file, use the spec file version. Update to new 1.6.1 release.
