### PR TITLE
Include systemd support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /fedora/argus-pdp.spec
 /rpmbuild
 /argus-pdp
+.project

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release = 0
 dist_url = http://argus-authz.github.com/$(name)/distrib/$(name)-$(version).tar.gz
 
 git_url = https://github.com/argus-authz/$(name).git
-git_branch = EMI-3
+git_branch = feature/ISSUE-1
 
 spec_file = fedora/$(name).spec
 rpmbuild_dir = $(CURDIR)/rpmbuild

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release = 0
 dist_url = http://argus-authz.github.com/$(name)/distrib/$(name)-$(version).tar.gz
 
 git_url = https://github.com/argus-authz/$(name).git
-git_branch = feature/ISSUE-1
+git_branch = EMI-3
 
 spec_file = fedora/$(name).spec
 rpmbuild_dir = $(CURDIR)/rpmbuild

--- a/fedora/argus-pdp.spec.in
+++ b/fedora/argus-pdp.spec.in
@@ -158,7 +158,16 @@ fi
 %{_localstatedir}/lib/argus/pdp/lib/provided/voms-api-java-*.jar
 %dir %{_localstatedir}/log/argus/pdp
 
+%if 0%{?rhel} >= 7 || 0%{?fedora} >= 21
+/lib/systemd/system/argus-pdp.service
+%else
+%exclude /lib/systemd/system/argus-pdp.service
+%endif
+
 %changelog
+* Tue Nov 17 2015 Marco Caberletti <marco.caberletti@cnaf.infn.it> 1.7.0-1
+- Add systemd unit file.
+
 * Tue Sep 8 2015 Andrea Ceccanti <andrea.ceccanti@cnaf.infn.it> 1.7.0-0
 - Pre-release packaging for 1.7.0
 


### PR DESCRIPTION
Add unit file to manage Argus services with systemd in EL7 and Fedora.
